### PR TITLE
feat: adding missing labels

### DIFF
--- a/src/utils/get-product-label.ts
+++ b/src/utils/get-product-label.ts
@@ -4,6 +4,8 @@ const getProductLabel = (label: number): string => {
   switch (label) {
     case ProductLabel.DAIRY:
       return 'Laticínios';
+    case ProductLabel.MEATS:
+      return 'Carnes';
     case ProductLabel.HAMBURGERS:
       return 'Hambúrgueres';
     case ProductLabel.PROCESSED:


### PR DESCRIPTION
This pull request makes a small update to the `getProductLabel` utility function to support an additional product label.

* Added support for the `ProductLabel.MEATS` label, returning 'Carnes' when this label is provided.