### PR TITLE
Fix profit calculations

### DIFF
--- a/src/backend/database/orders/insert-order.ts
+++ b/src/backend/database/orders/insert-order.ts
@@ -28,7 +28,6 @@ const insertOrder = async (orderData: InsertOrderInput): Promise<string> => {
 
     let subtotal = 0;
     let totalPurchaseCost = 0;
-    let totalProfit = 0;
 
     const orderItems: Array<{
       productInfo: Product;
@@ -70,7 +69,6 @@ const insertOrder = async (orderData: InsertOrderInput): Promise<string> => {
       const totalProfitItem = unitProfit * item.quantity;
 
       totalPurchaseCost += unitPurchasePrice * item.quantity;
-      totalProfit += totalProfitItem;
 
       orderItems.push({
         productInfo,
@@ -83,8 +81,10 @@ const insertOrder = async (orderData: InsertOrderInput): Promise<string> => {
     }
 
     const total = subtotal - discount + tax;
-    const profitMarginPercentage =
-      subtotal > 0 ? (totalProfit / subtotal) * 100 : 0;
+
+    const totalProfit = total - totalPurchaseCost;
+
+    const profitMarginPercentage = total > 0 ? (totalProfit / total) * 100 : 0;
 
     const orderSql = `
       INSERT INTO orders (

--- a/src/integrations/migrations/1758114384660_updating-profit-calculation.js
+++ b/src/integrations/migrations/1758114384660_updating-profit-calculation.js
@@ -1,0 +1,41 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  // Update existing orders to recalculate profit considering discount and tax
+  pgm.sql(`
+    UPDATE orders
+    SET
+      total_profit = (subtotal - discount + tax) - total_purchase_cost,
+      profit_margin_percentage = CASE
+        WHEN (subtotal - discount + tax) > 0
+        THEN (((subtotal - discount + tax) - total_purchase_cost) / (subtotal - discount + tax)) * 100
+        ELSE 0
+      END
+    WHERE total_purchase_cost IS NOT NULL;
+  `);
+};
+
+exports.down = (pgm) => {
+  // Revert to old calculation (item profits sum)
+  pgm.sql(`
+    UPDATE orders
+    SET
+      total_profit = (
+        SELECT COALESCE(SUM(oi.total_profit), 0)
+        FROM order_items oi
+        WHERE oi.order_id = orders.id
+      ),
+      profit_margin_percentage = CASE
+        WHEN subtotal > 0
+        THEN ((
+          SELECT COALESCE(SUM(oi.total_profit), 0)
+          FROM order_items oi
+          WHERE oi.order_id = orders.id
+        ) / subtotal) * 100
+        ELSE 0
+      END
+    WHERE total_purchase_cost IS NOT NULL;
+  `);
+};

--- a/tests/integration/api/v1/orders/client/id/get.test.ts
+++ b/tests/integration/api/v1/orders/client/id/get.test.ts
@@ -332,7 +332,7 @@ describe('GET /api/v1/orders/client/[id]', () => {
     expect(orderWithProfitItems.total_profit).toBeGreaterThan(0);
     expect(orderWithProfitItems.profit_margin_percentage).toBeGreaterThan(0);
 
-    expect(orderWithProfitItems.total_profit).toBeCloseTo(125, 1);
+    expect(orderWithProfitItems.total_profit).toBeCloseTo(110, 1);
   });
 
   it('should return zero profit data for orders without profit items', async () => {
@@ -356,7 +356,7 @@ describe('GET /api/v1/orders/client/[id]', () => {
       expect(order.total_purchase_cost).toBe(0);
 
       expect(order.total_profit).toBeGreaterThan(0);
-      expect(order.total_profit).toBe(order.subtotal);
+      expect(order.total_profit).toBe(order.total);
 
       expect(order.profit_margin_percentage).toBe(100);
     });
@@ -377,15 +377,13 @@ describe('GET /api/v1/orders/client/[id]', () => {
       expect(order.profit_margin_percentage).toBeGreaterThanOrEqual(0);
       expect(order.profit_margin_percentage).toBeLessThanOrEqual(100);
 
-      if (order.subtotal > 0) {
-        const expectedPercentage = (order.total_profit / order.subtotal) * 100;
+      if (order.total > 0) {
+        const expectedPercentage = (order.total_profit / order.total) * 100;
         expect(order.profit_margin_percentage).toBeCloseTo(
           expectedPercentage,
           1
         );
       }
-
-      expect(order.total_profit).toBeLessThanOrEqual(order.subtotal);
 
       if (order.discount > 0) {
         expect(order.total).toBeLessThan(order.subtotal);

--- a/tests/integration/api/v1/orders/get.test.ts
+++ b/tests/integration/api/v1/orders/get.test.ts
@@ -506,7 +506,7 @@ describe('GET /api/v1/orders', () => {
     expect(order).toBeDefined();
 
     expect(order.total_purchase_cost).toBe(0);
-    expect(order.total_profit).toBe(50.0);
+    expect(order.total_profit).toBe(45.0);
     expect(order.profit_margin_percentage).toBe(100);
     expect(order.subtotal).toBe(50.0);
   });
@@ -536,8 +536,8 @@ describe('GET /api/v1/orders', () => {
 
     expect(order.subtotal).toBe(80.0);
     expect(order.total_purchase_cost).toBe(50.0);
-    expect(order.total_profit).toBe(30.0);
-    expect(order.profit_margin_percentage).toBe(37.5);
+    expect(order.total_profit).toBe(20.0);
+    expect(order.profit_margin_percentage).toBeCloseTo(28.57, 1);
   });
 
   it('should handle decimal quantities in profit calculations', async () => {
@@ -665,8 +665,8 @@ describe('GET /api/v1/orders', () => {
       expect(order.profit_margin_percentage).toBeGreaterThanOrEqual(0);
       expect(order.profit_margin_percentage).toBeLessThanOrEqual(100);
 
-      if (order.subtotal > 0) {
-        const expectedPercentage = (order.total_profit / order.subtotal) * 100;
+      if (order.total > 0) {
+        const expectedPercentage = (order.total_profit / order.total) * 100;
         expect(order.profit_margin_percentage).toBeCloseTo(
           expectedPercentage,
           1
@@ -753,8 +753,8 @@ describe('GET /api/v1/orders', () => {
 
     expect(order.subtotal).toBe(65.0);
     expect(order.total_purchase_cost).toBe(25.0);
-    expect(order.total_profit).toBe(40.0);
-    expect(order.profit_margin_percentage).toBeCloseTo(61.54, 1);
+    expect(order.total_profit).toBe(35.0);
+    expect(order.profit_margin_percentage).toBeCloseTo(58.33, 1);
   });
 
   it('should verify product label snapshot behavior in order items', async () => {

--- a/tests/integration/api/v1/orders/id/delete.test.ts
+++ b/tests/integration/api/v1/orders/id/delete.test.ts
@@ -181,7 +181,7 @@ describe('DELETE /api/v1/orders/[id]', () => {
 
     expect(order.subtotal).toBe(200.0);
     expect(order.total_purchase_cost).toBe(125.0);
-    expect(order.total_profit).toBe(75.0);
+    expect(order.total_profit).toBe(65.0);
 
     const deleteResponse = await fetch(`${apiUrl}/api/v1/orders/${orderId}`, {
       method: 'DELETE',
@@ -218,7 +218,7 @@ describe('DELETE /api/v1/orders/[id]', () => {
 
     expect(order.subtotal).toBe(130.0);
     expect(order.total_purchase_cost).toBe(50.0);
-    expect(order.total_profit).toBe(80.0);
+    expect(order.total_profit).toBe(75.0);
 
     const deleteResponse = await fetch(`${apiUrl}/api/v1/orders/${orderId}`, {
       method: 'DELETE',
@@ -256,7 +256,7 @@ describe('DELETE /api/v1/orders/[id]', () => {
 
     expect(order.subtotal).toBe(255.0);
     expect(order.total_purchase_cost).toBe(112.5);
-    expect(order.total_profit).toBe(142.5);
+    expect(order.total_profit).toBe(140.5);
     expect(order.items.length).toBe(2);
 
     const deleteResponse = await fetch(`${apiUrl}/api/v1/orders/${orderId}`, {

--- a/tests/integration/api/v1/orders/id/get.test.ts
+++ b/tests/integration/api/v1/orders/id/get.test.ts
@@ -334,7 +334,7 @@ describe('GET /api/v1/orders/[id]', () => {
     expect(order.total).toBe(148.5);
 
     expect(order.total_purchase_cost).toBe(0);
-    expect(order.total_profit).toBe(151.0);
+    expect(order.total_profit).toBe(148.5);
     expect(order.profit_margin_percentage).toBe(100);
   });
 
@@ -356,8 +356,8 @@ describe('GET /api/v1/orders/[id]', () => {
 
     expect(order.subtotal).toBe(150.0);
     expect(order.total_purchase_cost).toBe(90.0);
-    expect(order.total_profit).toBe(60.0);
-    expect(order.profit_margin_percentage).toBe(40.0);
+    expect(order.total_profit).toBe(55.0);
+    expect(order.profit_margin_percentage).toBeCloseTo(37.93, 1);
 
     expect(order.total).toBe(145.0);
   });
@@ -672,8 +672,8 @@ describe('GET /api/v1/orders/[id]', () => {
     expect(order.profit_margin_percentage).toBeGreaterThanOrEqual(0);
     expect(order.profit_margin_percentage).toBeLessThanOrEqual(100);
 
-    if (order.subtotal > 0) {
-      const expectedPercentage = (order.total_profit / order.subtotal) * 100;
+    if (order.total > 0) {
+      const expectedPercentage = (order.total_profit / order.total) * 100;
       expect(order.profit_margin_percentage).toBeCloseTo(expectedPercentage, 1);
     }
 

--- a/tests/integration/api/v1/orders/post.test.ts
+++ b/tests/integration/api/v1/orders/post.test.ts
@@ -224,8 +224,8 @@ describe('POST /api/v1/orders', () => {
 
     expect(order.subtotal).toBe(160.0);
     expect(order.total_purchase_cost).toBe(100.0);
-    expect(order.total_profit).toBe(60.0);
-    expect(order.profit_margin_percentage).toBe(37.5);
+    expect(order.total_profit).toBe(50.0);
+    expect(order.profit_margin_percentage).toBeCloseTo(33.33, 1);
   });
 
   it('should create an order with mixed profit and non-profit items', async () => {
@@ -267,7 +267,7 @@ describe('POST /api/v1/orders', () => {
 
     expect(order.subtotal).toBe(130.0);
     expect(order.total_purchase_cost).toBe(50.0);
-    expect(order.total_profit).toBe(80.0);
+    expect(order.total_profit).toBe(75.0);
   });
 
   it('should create an order and preserve product label information in order items', async () => {


### PR DESCRIPTION
This pull request updates how order profit and profit margin percentage are calculated throughout the backend and database, ensuring that discounts and taxes are properly accounted for in all calculations. The changes affect the order insertion logic, database migration scripts, and a wide range of integration tests to reflect the new profit calculation method.

**Order profit calculation improvements:**

* Updated `insertOrder` logic in `src/backend/database/orders/insert-order.ts` to calculate `total_profit` as `total - total_purchase_cost` and `profit_margin_percentage` as `(total_profit / total) * 100`, where `total` includes discounts and taxes. This replaces the previous approach that summed item profits and used `subtotal` as the denominator. [[1]](diffhunk://#diff-725b57c172def5f000ca30e8ac8690c7836e0e882cd133ae2244dd419672f532L31) [[2]](diffhunk://#diff-725b57c172def5f000ca30e8ac8690c7836e0e882cd133ae2244dd419672f532L73) [[3]](diffhunk://#diff-725b57c172def5f000ca30e8ac8690c7836e0e882cd133ae2244dd419672f532L86-R87)

**Database migration:**

* Added a migration (`src/integrations/migrations/1758114384660_updating-profit-calculation.js`) to update existing orders, recalculating `total_profit` and `profit_margin_percentage` using the new logic. The migration also includes a down script to revert to the old calculation if needed.

**Test updates for new calculation:**

* Adjusted expected values and assertions in integration tests for GET, POST, and DELETE order endpoints to match the new profit and margin calculations, including changes to denominators and expected results. [[1]](diffhunk://#diff-34dd536a53e2857c637a65a4bb9e457b981aa5a8a0349a1f998976c6e271a29aL335-R335) [[2]](diffhunk://#diff-34dd536a53e2857c637a65a4bb9e457b981aa5a8a0349a1f998976c6e271a29aL359-R359) [[3]](diffhunk://#diff-34dd536a53e2857c637a65a4bb9e457b981aa5a8a0349a1f998976c6e271a29aL380-L389) [[4]](diffhunk://#diff-5e183e20ab28cdab7f4ee540d26a2273633260d93294aba8454d367650cdec5cL509-R509) [[5]](diffhunk://#diff-5e183e20ab28cdab7f4ee540d26a2273633260d93294aba8454d367650cdec5cL539-R540) [[6]](diffhunk://#diff-5e183e20ab28cdab7f4ee540d26a2273633260d93294aba8454d367650cdec5cL668-R669) [[7]](diffhunk://#diff-5e183e20ab28cdab7f4ee540d26a2273633260d93294aba8454d367650cdec5cL756-R757) [[8]](diffhunk://#diff-b3984a9dc22af77959b70e86675ff69ff312eafef0d7e3f0c60f272361eda421L184-R184) [[9]](diffhunk://#diff-b3984a9dc22af77959b70e86675ff69ff312eafef0d7e3f0c60f272361eda421L221-R221) [[10]](diffhunk://#diff-b3984a9dc22af77959b70e86675ff69ff312eafef0d7e3f0c60f272361eda421L259-R259) [[11]](diffhunk://#diff-5a51522c0455af8e56797430f9c5e17f3ab8ad73948525a1931b63a05a23a9faL337-R337) [[12]](diffhunk://#diff-5a51522c0455af8e56797430f9c5e17f3ab8ad73948525a1931b63a05a23a9faL359-R360) [[13]](diffhunk://#diff-5a51522c0455af8e56797430f9c5e17f3ab8ad73948525a1931b63a05a23a9faL675-R676) [[14]](diffhunk://#diff-96746a4993df37674daf29b289df455c68039f4b628fda820667799453a7acbbL227-R228) [[15]](diffhunk://#diff-96746a4993df37674daf29b289df455c68039f4b628fda820667799453a7acbbL270-R270)